### PR TITLE
Fix issue when uds message is longer than 62 bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## Current version
+
+### Bugfixes
+- Fix sending uds message longer than 62 bytes by CAN
+
 ## [3.0.1]
 
 ## Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ## Current version
 
 ### Bugfixes
-- Fix sending uds message longer than 62 bytes by CAN
+- Fix padding of consecutive frames over CAN
 
 ## [3.0.1]
 

--- a/test/Uds/Unit Tests/unittest_CanTp.py
+++ b/test/Uds/Unit Tests/unittest_CanTp.py
@@ -962,9 +962,8 @@ class CanTpTestCase(unittest.TestCase):
 
     @patch("can.interfaces.virtual.VirtualBus.send")
     @patch("uds.CanTp.getNextBufferedMessage")
-    @patch("uds.CanTp.transmit")
     def test_canTpLargeMultiFrameWithMultipleBlockChangingBlockSizeDuringTransmission(
-        self, can_transmit_mocker, getNextMessageMock, canSendMock
+        self, getNextMessageMock, canSendMock
     ):
 
         result = []
@@ -1016,10 +1015,8 @@ class CanTpTestCase(unittest.TestCase):
             payload.append(i % 256)
 
         tpConnection = CanTp(reqId=0x600, resId=0x650)
-        can_transmit_mocker.side_effect = None
         tpConnection.send(payload)
 
-        can_transmit_mocker.assert_called()
         expectedResult = [
             0x11,
             0xF4,

--- a/test/Uds/Unit Tests/unittest_CanTp.py
+++ b/test/Uds/Unit Tests/unittest_CanTp.py
@@ -12,17 +12,145 @@ __status__ = "Development"
 
 import unittest
 from unittest.mock import patch
+from parameterized import parameterized
 
 from uds import CanTp
+from uds.config import Config
+
+PADDING_PATTERN = [CanTp.PADDING_PATTERN]
+
+
+class CanTpMocker(CanTp):
+    @patch("uds.config.IsoTpConfig")
+    def __init__(
+        self,
+        iso_mocker,
+        Mtype="DIAGNOSTICS",
+        adressing_type="NORMAL",
+        connector=None,
+        **kwargs
+    ):
+        iso_mocker.m_type = Mtype
+        iso_mocker.addressing_type = adressing_type
+        Config.isotp = iso_mocker
+
+        super().__init__(connector=connector, **kwargs)
 
 
 class CanTpTestCase(unittest.TestCase):
+    @parameterized.expand(
+        [
+            (3, 4),
+            (7, 0),
+            (8, 3),
+            (11, 0),
+            (13, 2),
+            (15, 0),
+            (16, 3),
+            (19, 0),
+            (22, 1),
+            (23, 0),
+            (28, 3),
+            (31, 0),
+            (39, 8),
+            (47, 0),
+            (56, 7),
+            (63, 0),
+        ]
+    )
+    def test_create_blocklist_payload_inferior_than_63_bytes(
+        self, len_payload, len_padding_expected
+    ):
+        test_val = []
+        for i in range(0, len_payload):
+            test_val.append(0xFF)
+
+        tp_connection = CanTpMocker()
+
+        a = tp_connection.create_blockList(test_val, 1)
+
+        self.assertEqual(a, [[test_val + len_padding_expected * PADDING_PATTERN]])
+
+    def test_create_blocklist_longer_than_63_bytes_blocksize_1(self):
+        test_val = []
+        for i in range(0, 66):
+            test_val.append(0xFF)
+
+        tp_connection = CanTpMocker()
+
+        a = tp_connection.create_blockList(test_val, 1)
+
+        self.assertEqual(
+            a,
+            [
+                [test_val[:63]],
+                [test_val[63:] + (7 - len(test_val[63:])) * PADDING_PATTERN],
+            ],
+        )
+
+    def test_create_blocklist_longer_than_63_bytes_blocksize_2(self):
+        test_val = []
+        for i in range(0, 66):
+            test_val.append(0xFF)
+
+        tp_connection = CanTpMocker()
+
+        a = tp_connection.create_blockList(test_val, 2)
+
+        self.assertEqual(
+            a,
+            [
+                [
+                    test_val[:63],
+                    test_val[63:] + (7 - len(test_val[63:])) * PADDING_PATTERN,
+                ],
+            ],
+        )
+
+    def test_create_blocklist_no_block_size_pdu(self):
+        testVal = []
+        for i in range(0, 4089):
+            testVal.append(0xFF)
+
+        result = []
+
+        for i in range(64):
+            result.append([0xFF] * 63)
+
+        result.append([0xFF] * 57 + [0x0] * 6)
+
+        tpConnection = CanTpMocker()
+
+        a = tpConnection.create_blockList(testVal, 585)
+        self.assertEqual(a, [result])
+
+    @parameterized.expand(
+        [
+            (4, 8),
+            (8, 8),
+            (11, 12),
+            (14, 16),
+            (16, 16),
+            (18, 20),
+            (21, 24),
+            (24, 24),
+            (28, 32),
+            (46, 48),
+            (55, 64),
+        ]
+    )
+    def test_get_padded_length(self, len_payload, expected_padded_length):
+        tpConnection = CanTpMocker()
+
+        self.assertEqual(
+            expected_padded_length, tpConnection.get_padded_length(len_payload)
+        )
+
     def test_canTpRaiseExceptionOnTooLargePayload(self):
         payload = []
         for i in range(0, 4096):
             payload.append(0)
-
-        tpConnection = CanTp(reqId=0x600, resId=0x650)
+        tpConnection = CanTpMocker()
         with self.assertRaises(Exception):
             tpConnection.send(payload)
 
@@ -834,8 +962,9 @@ class CanTpTestCase(unittest.TestCase):
 
     @patch("can.interfaces.virtual.VirtualBus.send")
     @patch("uds.CanTp.getNextBufferedMessage")
+    @patch("uds.CanTp.transmit")
     def test_canTpLargeMultiFrameWithMultipleBlockChangingBlockSizeDuringTransmission(
-        self, getNextMessageMock, canSendMock
+        self, can_transmit_mocker, getNextMessageMock, canSendMock
     ):
 
         result = []
@@ -887,9 +1016,10 @@ class CanTpTestCase(unittest.TestCase):
             payload.append(i % 256)
 
         tpConnection = CanTp(reqId=0x600, resId=0x650)
-
+        can_transmit_mocker.side_effect = None
         tpConnection.send(payload)
 
+        can_transmit_mocker.assert_called()
         expectedResult = [
             0x11,
             0xF4,
@@ -1470,143 +1600,6 @@ class CanTpTestCase(unittest.TestCase):
         ]
 
         self.assertEqual(expectedResult, result)
-
-    def test_canTpCreateBlock_oneBlockSinglePduNotFull(self):
-
-        testVal = []
-        for i in range(0, 6):
-            testVal.append(0xFF)
-
-        tpConnection = CanTp(reqId=0x600, resId=0x650)
-
-        a = tpConnection.create_blockList(testVal, 1)
-
-        self.assertEqual(a, [[[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00]]])
-
-    def test_canTpCreateBlock_oneBlockSinglePduFullSameAsBlockSize(self):
-
-        testVal = []
-        for i in range(0, 7):
-            testVal.append(0xFF)
-
-        tpConnection = CanTp(reqId=0x600, resId=0x650)
-
-        a = tpConnection.create_blockList(testVal, 1)
-
-        self.assertEqual(a, [[[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]]])
-
-    def test_canTpCreateBlock_oneBlockSinglePduFullSmallerThanBlockSize(self):
-
-        testVal = []
-        for i in range(0, 7):
-            testVal.append(0xFF)
-
-        tpConnection = CanTp(reqId=0x600, resId=0x650)
-
-        a = tpConnection.create_blockList(testVal, 2)
-
-        self.assertEqual(a, [[[0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]]])
-
-    def test_canTpCreateBlock_oneBlockTwoPduNotFull(self):
-        testVal = []
-        for i in range(0, 13):
-            testVal.append(0xFF)
-
-        tpConnection = CanTp(reqId=0x600, resId=0x650)
-
-        a = tpConnection.create_blockList(testVal, 2)
-
-        self.assertEqual(
-            a,
-            [
-                [
-                    [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF],
-                    [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00],
-                ]
-            ],
-        )
-
-    def test_canTpCreateBlock_oneBlockTwoPduFull(self):
-        testVal = []
-        for i in range(0, 14):
-            testVal.append(0xFF)
-
-        tpConnection = CanTp(reqId=0x600, resId=0x650)
-
-        a = tpConnection.create_blockList(testVal, 2)
-
-        self.assertEqual(
-            a,
-            [
-                [
-                    [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF],
-                    [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF],
-                ]
-            ],
-        )
-
-    def test_canTpCreateBlock_twoBlockTwoPduNotFull(self):
-        testVal = []
-        for i in range(0, 27):
-            testVal.append(0xFF)
-
-        tpConnection = CanTp(reqId=0x600, resId=0x650)
-
-        a = tpConnection.create_blockList(testVal, 2)
-
-        self.assertEqual(
-            a,
-            [
-                [
-                    [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF],
-                    [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF],
-                ],
-                [
-                    [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF],
-                    [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x00],
-                ],
-            ],
-        )
-
-    def test_canTpCreateBlock_twoBlockTwoPduFull(self):
-        testVal = []
-        for i in range(0, 28):
-            testVal.append(0xFF)
-
-        tpConnection = CanTp(reqId=0x600, resId=0x650)
-
-        a = tpConnection.create_blockList(testVal, 2)
-
-        self.assertEqual(
-            a,
-            [
-                [
-                    [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF],
-                    [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF],
-                ],
-                [
-                    [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF],
-                    [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF],
-                ],
-            ],
-        )
-
-    def test_canTpCreateBlock_noBlockSizePdu(self):
-        testVal = []
-        for i in range(0, 4089):
-            testVal.append(0xFF)
-
-        result = []
-        for i in range(584):
-            result.append([0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF])
-
-        result.append([0xFF, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00])
-
-        tpConnection = CanTp(reqId=0x600, resId=0x650)
-
-        a = tpConnection.create_blockList(testVal, 585)
-
-        self.assertEqual(a[0], result)
 
 
 if __name__ == "__main__":

--- a/uds/uds_communications/TransportProtocols/Can/CanTp.py
+++ b/uds/uds_communications/TransportProtocols/Can/CanTp.py
@@ -394,24 +394,18 @@ class CanTp(TpInterface):
         blockPtr = 0
 
         payloadLength = len(payload)
+        pduLength = self.__maxPduLength
+        blockLength = blockSize * pduLength
         working = True
         while working:
-            pduLength = (
-                next(
-                    (
-                        size
-                        for size in CAN_FD_DATA_LENGTHS
-                        if size + payloadPtr > payloadLength
-                    ),
-                    64,
-                )
-                - 1
-            )
-            blockLength = blockSize * pduLength
+
             if (payloadPtr + pduLength) >= payloadLength:
                 working = False
+                curr_payload = payload[payloadPtr:]
                 currPdu = fillArray(
-                    payload[payloadPtr:], pduLength, fillValue=self.PADDING_PATTERN
+                    curr_payload,
+                    self.get_padded_length(len(curr_payload)) - 1,
+                    fillValue=self.PADDING_PATTERN,
                 )
                 currBlock.append(currPdu)
                 blockList.append(currBlock)
@@ -428,6 +422,15 @@ class CanTp(TpInterface):
                     blockPtr = 0
 
         return blockList
+
+    @staticmethod
+    def get_padded_length(msg_length: int) -> int:
+        """Get the size of the CAN FD message needed to send a message.
+
+        :param msg_length: length of the message to send
+        :return: size of the CAN FD message
+        """
+        return next(size for size in CAN_FD_DATA_LENGTHS if size > msg_length)
 
     ##
     # @brief transmits the data over can using can connection

--- a/uds/uds_communications/TransportProtocols/Can/CanTp.py
+++ b/uds/uds_communications/TransportProtocols/Can/CanTp.py
@@ -404,7 +404,7 @@ class CanTp(TpInterface):
                 curr_payload = payload[payloadPtr:]
                 currPdu = fillArray(
                     curr_payload,
-                    self.get_padded_length(len(curr_payload)) - 1,
+                    self.get_padded_length(len(curr_payload) + 1) - 1,
                     fillValue=self.PADDING_PATTERN,
                 )
                 currBlock.append(currPdu)
@@ -430,7 +430,7 @@ class CanTp(TpInterface):
         :param msg_length: length of the message to send
         :return: size of the CAN FD message
         """
-        return next(size for size in CAN_FD_DATA_LENGTHS if size > msg_length)
+        return next(size for size in CAN_FD_DATA_LENGTHS if size >= msg_length)
 
     ##
     # @brief transmits the data over can using can connection


### PR DESCRIPTION
Issue happens when you use the function `send_uds_raw`  from UdsAuxiliary of kiso-testing with the following code :
```python
req = [0x27, 0x42] + 64 * [0xFF] 
uds_aux.send_uds_raw(req) 
```
And the messages send were : 
```
 10 40 27 42 FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF FF
 21 FF FF FF FF 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 ```
 Instead of sending a message of 8 bytes for the last 4 bytes of data it send a message 64 bytes long